### PR TITLE
fix: 修正多行文本的处理

### DIFF
--- a/fcm/Commands/Add.cs
+++ b/fcm/Commands/Add.cs
@@ -18,16 +18,17 @@ namespace fcm.Commands
 
             foreach (string fun in funs)
             {
-                if (funFile.Contains(fun))
+                string normalizedfun = fun.Replace("\n", "\\n");
+                if (funFile.Contains(normalizedfun))
                 {
-                    AnsiConsole.MarkupLine($"{Print.MSHead.Warning} {Markup.Escape(fun)} {Strings.IsAlreadyInFunTxt}");
+                    AnsiConsole.MarkupLine($"{Print.MSHead.Warning} {Markup.Escape(normalizedfun)} {Strings.IsAlreadyInFunTxt}");
                     continue;
                 }
                 else
                 {
                     isAdded = true;
-                    funFile.Add(fun);
-                    AnsiConsole.MarkupLine($"{Print.MSHead.Success} {string.Format(Strings.HasBeenAddedToFunTxt, Markup.Escape(fun))}");
+                    funFile.Add(normalizedfun);
+                    AnsiConsole.MarkupLine($"{Print.MSHead.Success} {string.Format(Strings.HasBeenAddedToFunTxt, Markup.Escape(normalizedfun))}");
                 }
             }
 

--- a/fcm/Commands/Remove.cs
+++ b/fcm/Commands/Remove.cs
@@ -18,15 +18,16 @@ namespace fcm.Commands
 
             foreach (string fun in funs)
             {
-                if (funFile.Contains(fun))
+                string normalizedfun = fun.Replace("\n", "\\n");
+                if (funFile.Contains(normalizedfun))
                 {
                     isRemoved = true;
-                    funFile.RemoveAll(line => line == fun);
-                    AnsiConsole.MarkupLine($"{Print.MSHead.Success} {string.Format(Strings.HasBeenRemovedFromFunTxt, Markup.Escape(fun))}");
+                    funFile.RemoveAll(line => line == normalizedfun);
+                    AnsiConsole.MarkupLine($"{Print.MSHead.Success} {string.Format(Strings.HasBeenRemovedFromFunTxt, Markup.Escape(normalizedfun))}");
                 }
                 else
                 {
-                    AnsiConsole.MarkupLine($"{Print.MSHead.Warning} {Markup.Escape(fun)} {Strings.IsNotInFunTxt}");
+                    AnsiConsole.MarkupLine($"{Print.MSHead.Warning} {Markup.Escape(normalizedfun)} {Strings.IsNotInFunTxt}");
                     continue;
                 }
             }

--- a/fcm/Commands/Search.cs
+++ b/fcm/Commands/Search.cs
@@ -41,7 +41,7 @@ namespace fcm.Commands
                     continue;
                 }
 
-                if (!filteredKeywords.All(k => line.Contains(k)))
+                if (!filteredKeywords.All(k => line.Contains(k.Replace("\n", "\\n"))))
                 {
                     continue;
                 }


### PR DESCRIPTION
影响 Add、Remove 和 Search，在处理前先转 `\n` 为 `\\n`，提示信息使用处理后的文本。