### PR TITLE
fix(search): escape markup before highlighting

### DIFF
--- a/fcm/Commands/Search.cs
+++ b/fcm/Commands/Search.cs
@@ -46,9 +46,9 @@ namespace fcm.Commands
                     continue;
                 }
 
-                string pattern = string.Join("|", filteredKeywords.Select(Regex.Escape));
-                string result = Regex.Replace(line, pattern, match => $"[blue]{match.Value}[/]");
-                table.AddRow(result.Replace("\\n", "\n"));
+                string escapedLine = Markup.Escape(line);
+                string pattern = string.Join("|", filteredKeywords.Select(keyword => Regex.Escape(Markup.Escape(keyword))));
+                string result = Regex.Replace(escapedLine, pattern, match => $"[blue]{match.Value}[/]");
             }
 
             AnsiConsole.Write(table);


### PR DESCRIPTION
## Summary
- escape the original search result line before adding Spectre.Console markup
- build the keyword highlight regex from escaped keywords so highlighting still works after escaping
- prevent invalid user content tags from being parsed as Spectre markup and crashing search output

## Testing
- verified issue #7 is still open and the Development section has no linked PR
- inspected the current search implementation and confirmed it highlighted matches on the raw line before rendering markup
- verified the compare diff is a single-file 3-line replacement in `fcm/Commands/Search.cs`

Fixes #7