### PR TITLE
i18n: 修改 fcm dup 的参数说明的资源名称

### DIFF
--- a/fcm/Commands/Help.cs
+++ b/fcm/Commands/Help.cs
@@ -64,7 +64,7 @@ namespace fcm.Commands
                 ).AddRow(
                     "dep / ded / dup",
                     Strings.RemoveDuplicateLinesFromTheContent,
-                    Strings.TheLocationOfTheFileThatNeedToBeDeduplicated_LeaveBlankForTheDefaultLocation,
+                    Strings.TheLocationOfTheFilesThatNeedToBeDeduplicated_LeaveBlankForTheDefaultLocation,
                     "fcm dep fun.txt"
                 ).AddRow(
                     "--version",

--- a/fcm/Resources/Strings.Designer.cs
+++ b/fcm/Resources/Strings.Designer.cs
@@ -450,9 +450,9 @@ namespace fcm.Resources {
         /// <summary>
         ///   查找类似 The location of the files that need to be deduplicated; leave blank for the default location. 的本地化字符串。
         /// </summary>
-        internal static string TheLocationOfTheFileThatNeedToBeDeduplicated_LeaveBlankForTheDefaultLocation {
+        internal static string TheLocationOfTheFilesThatNeedToBeDeduplicated_LeaveBlankForTheDefaultLocation {
             get {
-                return ResourceManager.GetString("TheLocationOfTheFileThatNeedToBeDeduplicated_LeaveBlankForTheDefaultLocation", resourceCulture);
+                return ResourceManager.GetString("TheLocationOfTheFilesThatNeedToBeDeduplicated_LeaveBlankForTheDefaultLocation", resourceCulture);
             }
         }
         

--- a/fcm/Resources/Strings.en-US.resx
+++ b/fcm/Resources/Strings.en-US.resx
@@ -204,7 +204,7 @@
   <data name="HasBeenRemovedFromFunTxt" xml:space="preserve">
     <value>{0} has been removed from fun.txt.</value>
   </data>
-  <data name="TheLocationOfTheFileThatNeedToBeDeduplicated_LeaveBlankForTheDefaultLocation" xml:space="preserve">
+  <data name="TheLocationOfTheFilesThatNeedToBeDeduplicated_LeaveBlankForTheDefaultLocation" xml:space="preserve">
     <value>The location of the files that need to be deduplicated; leave blank for the default location.</value>
   </data>
   <data name="ThePathOfTheFileToBeExportedTo" xml:space="preserve">

--- a/fcm/Resources/Strings.resx
+++ b/fcm/Resources/Strings.resx
@@ -232,7 +232,7 @@
     <value>{0} has been removed from fun.txt.</value>
     <comment>fcm remove 的成功提示</comment>
   </data>
-  <data name="TheLocationOfTheFileThatNeedToBeDeduplicated_LeaveBlankForTheDefaultLocation" xml:space="preserve">
+  <data name="TheLocationOfTheFilesThatNeedToBeDeduplicated_LeaveBlankForTheDefaultLocation" xml:space="preserve">
     <value>The location of the files that need to be deduplicated; leave blank for the default location.</value>
     <comment>fcm dup 的参数说明</comment>
   </data>

--- a/fcm/Resources/Strings.zh-CN.resx
+++ b/fcm/Resources/Strings.zh-CN.resx
@@ -204,7 +204,7 @@
   <data name="HasBeenRemovedFromFunTxt" xml:space="preserve">
     <value>已从 fun.txt 中移除 {0}。</value>
   </data>
-  <data name="TheLocationOfTheFileThatNeedToBeDeduplicated_LeaveBlankForTheDefaultLocation" xml:space="preserve">
+  <data name="TheLocationOfTheFilesThatNeedToBeDeduplicated_LeaveBlankForTheDefaultLocation" xml:space="preserve">
     <value>需要去重的文件的所在位置；留空为默认位置。</value>
   </data>
   <data name="ThePathOfTheFileToBeExportedTo" xml:space="preserve">


### PR DESCRIPTION
`File` → `Files`

为了和中性值保持一致。