### PR TITLE
ci(release): 从新 url 下载 ChineseSimplified.isl

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,17 @@ jobs:
       - name: 打包安装程序
         shell: bash
         run: |-
-          curl -o "C:\Program Files (x86)\Inno Setup 6\Languages\ChineseSimplified.isl" "https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/Unofficial/ChineseSimplified.isl"
+          if ((Get-Date) -le (Get-Date "2026-06-29")) {
+            Write-Host "通过 GitHub API 下载中文翻译..."
+            $apiUrl = "https://api.github.com/repos/jrsoftware/issrc/contents/Files/Languages/ChineseSimplified.isl?ref=main"
+            $downloadPath = "C:\Program Files (x86)\Inno Setup 6\Languages\ChineseSimplified.isl"
+            Invoke-WebRequest -Uri $apiUrl -Headers @{ "Accept" = "application/vnd.github.raw+json" } -OutFile $downloadPath
+            Get-FileHash -Path $downloadPath -Algorithm SHA256
+          } else {
+            Write-Error "Inno Setup 7.0.2 应该今天会发布，请使用包含官方翻译的新版本"
+            exit -1
+          }
+
           iscc installer.iss
 
       - name: 上传构建文件


### PR DESCRIPTION
这是一个临时的操作，依据他们的 https://github.com/jrsoftware/issrc/blob/main/whatsnew.htm ，他们会在下个版本发布带有官方中文翻译的 Inno Setup。
我不打算检查下载下来的文件的哈希值，因为他们还在不断修改翻译文件。
